### PR TITLE
Enable pruning when node error rate equals children error rate

### DIFF
--- a/id3/tree.py
+++ b/id3/tree.py
@@ -131,7 +131,7 @@ class TreeBuilder(BaseBuilder):
                                                  - node.predicts[max_class],
                                                  n_predicts)
 
-                if node_error_rate < children_error_rate:
+                if node_error_rate <= children_error_rate:
                     node.is_feature = False
                     node.value = max_class
                     node.n_correct_predicts = node.predicts[max_class]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ except ImportError:
     sys.exit(1)
 
 setup(name='decision-tree-id3',
-      version='0.1.2',
+      version='0.1.3',
       description='A scikit-learn compatible package for id3 decision tree',
       author='Daniel Pettersson, Otto Nordander',
       packages=find_packages(),


### PR DESCRIPTION
I agree with the assessment in issue #1, here's a very small PR with the appropriate patch